### PR TITLE
Bugfix/abiotic factor steamcmd

### DIFF
--- a/.ado/docker-build.yaml
+++ b/.ado/docker-build.yaml
@@ -18,7 +18,7 @@ stages:
       matrix:
         'abiotic-factor':
           servername: 'abiotic-factor'
-          Version: 1.0.0
+          Version: 1.0.1
     steps:
       - task: Docker@2
         inputs:

--- a/abiotic-factor/Dockerfile
+++ b/abiotic-factor/Dockerfile
@@ -7,7 +7,8 @@ RUN     /home/steam/steamcmd/steamcmd.sh \
 	    +force_install_dir /server \
 	    +login anonymous \
 	    +app_update 2857200 validate \
-	    +quit
+	    +quit && \
+	    cp /home/steam/steamcmd/steamcmd.sh /usr/local/bin/steamcmd
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN	dpkg --add-architecture i386 && \

--- a/abiotic-factor/Dockerfile
+++ b/abiotic-factor/Dockerfile
@@ -1,22 +1,22 @@
 FROM cm2network/steamcmd:steam-bookworm as base
 USER 0
-RUN mkdir /server && chmod 777 /server 
+RUN	    dpkg --add-architecture i386 && \
+	    mkdir /server && chmod 777 /server && \
+	    cp /home/steam/steamcmd/steamcmd.sh /usr/local/bin/steamcmd && \
+    	    apt update && apt install -y wget && \
+	    wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key && \
+	    mkdir -pm755 /etc/apt/keyrings && \
+	    wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources && \
+	    apt update && \
+	    apt install -y --install-recommends winehq-stable
 USER 1000
-RUN     /home/steam/steamcmd/steamcmd.sh \
+RUN         /home/steam/steamcmd/steamcmd.sh \
 	    +@sSteamCmdForcePlatformType windows \
 	    +force_install_dir /server \
 	    +login anonymous \
 	    +app_update 2857200 validate \
-	    +quit && \
-	    cp /home/steam/steamcmd/steamcmd.sh /usr/local/bin/steamcmd
+	    +quit
 
 COPY ./entrypoint.sh /entrypoint.sh
-RUN	dpkg --add-architecture i386 && \
-	apt update && apt install -y wget && \
-	wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key && \
-	mkdir -pm755 /etc/apt/keyrings && \
-	wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources && \
-	apt update && \
-	apt install -y --install-recommends winehq-stable
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/abiotic-factor/Dockerfile
+++ b/abiotic-factor/Dockerfile
@@ -9,8 +9,6 @@ RUN     /home/steam/steamcmd/steamcmd.sh \
 	    +app_update 2857200 validate \
 	    +quit
 
-FROM debian:bookworm as final
-COPY --from=base /server /server
 COPY ./entrypoint.sh /entrypoint.sh
 RUN	dpkg --add-architecture i386 && \
 	apt update && apt install -y wget && \
@@ -19,6 +17,5 @@ RUN	dpkg --add-architecture i386 && \
 	wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources && \
 	apt update && \
 	apt install -y --install-recommends winehq-stable
-EXPOSE 7777
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]


### PR DESCRIPTION
Refactored Dockerfile to:

1. Remove multistage
2. Ensure steamcmd is installed.
3. Moved steamcmd.sh to `/usr/local/bin/steamcmd` in order to allow it to be used as a command later.

closes #1 