### PR TITLE
Bugfix/abiotic factor steamcmd

### DIFF
--- a/abiotic-factor/Dockerfile
+++ b/abiotic-factor/Dockerfile
@@ -2,7 +2,7 @@ FROM cm2network/steamcmd:steam-bookworm as base
 USER 0
 RUN	    dpkg --add-architecture i386 && \
 	    mkdir /server && chmod 777 /server && \
-	    cp /home/steam/steamcmd/steamcmd.sh /usr/local/bin/steamcmd && \
+	    # cp /home/steam/steamcmd/steamcmd.sh /usr/local/bin/steamcmd && \
     	    apt update && apt install -y wget && \
 	    wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key && \
 	    mkdir -pm755 /etc/apt/keyrings && \
@@ -10,7 +10,7 @@ RUN	    dpkg --add-architecture i386 && \
 	    apt update && \
 	    apt install -y --install-recommends winehq-stable
 USER 1000
-RUN         /home/steam/steamcmd/steamcmd.sh \
+RUN         bash /home/steam/steamcmd.sh \
 	    +@sSteamCmdForcePlatformType windows \
 	    +force_install_dir /server \
 	    +login anonymous \

--- a/abiotic-factor/entrypoint.sh
+++ b/abiotic-factor/entrypoint.sh
@@ -20,7 +20,7 @@ AdditionalArgs="${AdditionalArgs:-}"
 
 # Check for updates/perform initial installation
 if [ ! -d "/server/AbioticFactor/Binaries/Win64" ] || [[ $AutoUpdate == "true" ]]; then
-    /home/steam/steamcmd/linux32/steamcmd \
+    bash /home/steam/steamcmd.sh \
     +@sSteamCmdForcePlatformType windows \
     +force_install_dir /server \
     +login anonymous \


### PR DESCRIPTION
Updated references to steamcmd to point at the script instead as the script does some weird stuff to set up relative paths and can't be executed from `/usr/local/bin`